### PR TITLE
docs(proto): clarify tarmac status codes so ops stop guessing

### DIFF
--- a/sdk/tarmac.proto
+++ b/sdk/tarmac.proto
@@ -8,9 +8,12 @@ option go_package = "github.com/tarmac-project/protobuf-go/sdk";
 //
 // The status code will indicate failure or success.
 //
-// Status codes are as follows:
-// 000 - Success
-// 100 - Failure
+// Possible status codes are:
+// 200 - Success
+// 206 - Success with partial metadata (rows affected / last insert ID unavailable)
+// 400 - Malformed or invalid request
+// 404 - Requested key not found in KV store
+// 500 - Internal server error
 //
 message Status {
   // Code is the status code for callback execution.

--- a/sdk/tarmac.proto
+++ b/sdk/tarmac.proto
@@ -10,7 +10,7 @@ option go_package = "github.com/tarmac-project/protobuf-go/sdk";
 //
 // Possible status codes are:
 // 200 - Success
-// 206 - Success with partial metadata (rows affected / last insert ID unavailable)
+// 206 - Success with partial metadata (rows affected)
 // 400 - Malformed or invalid request
 // 404 - Requested key not found in KV store
 // 500 - Internal server error


### PR DESCRIPTION
This pull request updates the documentation for status codes in the `sdk/tarmac.proto` file. The main change is the expansion and clarification of possible status codes to provide more detailed information about different response scenarios.

Status code documentation improvements:

* Expanded the list of possible status codes in the `Status` message to include `200` (Success), `206` (Success with partial metadata), `400` (Malformed or invalid request), `404` (Requested key not found in KV store), and `500` (Internal server error), replacing the previous generic codes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API status code descriptions to use standard codes: 200 (Success), 206 (Partial success), 400 (Malformed/invalid request), 404 (Key not found), and 500 (Internal server error), replacing the previous 000/100 scheme.
  * No functional or field changes; documentation-only update.
  * Improves clarity for interpreting responses and aids troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->